### PR TITLE
feat: add support for migrating from npm Enterprise legacy

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # pneumatic-tubes
 
-Transfer kappa registry mirror contents to an npmE appliance.
+Migrate from kappa, npm Enterprise Legacy, and npm Orgs, to npm Enterprise SaaS.
 
 ## Preparation
 
@@ -8,19 +8,25 @@ Transfer kappa registry mirror contents to an npmE appliance.
 - npm 5 - 5.6 (5.7+ are incompatible with npmE)
 - run `npm install`
 - login to your _target_ registry if needed: `npm --registry=<target-registry-url> login`
-- setup environment variables for these registries
-  - `PNEUMATIC_TUBES_SOURCE_COUCHDB = <source-couchdb-url>`
-  - `PNEUMATIC_TUBES_TARGET_REGISTRY = <target-registry-url>`
-  - _[optional]_ `PNEUMATIC_TUBES_LAST_SEQUENCE = <sequence-number>` defaults to `0` (zero)
 
-# IMPORTANT: You need to point the import script at the CouchDB instance associated with your kappa proxy. The kappa proxy itself doesn't foward the `_changes` feed, so direct couch access is necessary.
+## Importing From Kappa
 
-## Run the Script
+You need to point the import script at the CouchDB instance associated with your kappa proxy. The kappa proxy itself doesn't foward the `_changes` feed, so direct couch access is necessary.
 
-With all of the above setup steps complete, you shoud be ready to run the import:
+Run:
 
-```shell
-npm run import
+```bash
+./index.js couch-import --source-couch-db=[couch-db-url]/_changes --target-registry=[target-registry-url]
+```
+
+## Importing From Legacy npm Enterprise
+
+Fetch `Secret used between services` from your npm Enterprise console.
+
+Run:
+
+```bash
+./index.js couch-import --source-couch-db=[couch-db-url]/_changes --target-registry=[target-registry-url] --shared-fetch-secret=[password-from-console]
 ```
 
 ## Development
@@ -43,4 +49,3 @@ When backgrounded, you can tail its logs thus (includes 20 lines of context):
 ```shell
 docker logs --follow --tail 20 pneumatictubes_kappa_1
 ```
-

--- a/index.js
+++ b/index.js
@@ -26,7 +26,7 @@ const opts = require('yargs')
   })
   .option('tmp-folder', {
     describe: 'temporary folder to stage packages in',
-    default: '/tmp/tarballs',
+    default: '/tmp/tarballs'
   })
   .demandCommand(1)
   .argv
@@ -41,7 +41,9 @@ class Tubes {
     mkdirp.sync(this.tmpFolder)
   }
   start () {
-    new ChangesStreamSource(this, this.opts)
+    let source = null
+    source = new ChangesStreamSource(this, this.opts)
+    source.start()
   }
   publish (filename) {
     return new Promise((resolve, reject) => {

--- a/index.js
+++ b/index.js
@@ -1,79 +1,51 @@
-const axios = require('axios')
-const ChangesStream = require('changes-stream')
-const eos = require('end-of-stream')
-const exec = require('child_process').exec
-const fs = require('fs')
-const mkdirp = require('mkdirp')
-const path = require('path')
-const uuid = require('uuid')
+#!/usr/bin/env node
 
-const sourceCouchdb = process.env.PNEUMATIC_TUBES_SOURCE_COUCHDB
-const targetRegistry = process.env.PNEUMATIC_TUBES_TARGET_REGISTRY
-const lastSequence = process.env.PNEUMATIC_TUBES_LAST_SEQUENCE
+const exec = require('child_process').exec
+const mkdirp = require('mkdirp')
+const opts = require('yargs')
+  .command('couch-import', 'import from legacy changes feed', (yargs) => {
+    yargs
+      .option('source-couch-db', {
+        describe: 'changes feed to migrate (should include sharedFetchSecret)',
+        default: process.env.PNEUMATIC_TUBES_SOURCE_COUCHDB,
+        required: true
+      })
+      .option('shared-fetch-secret', {
+        describe: 'password for changes feed',
+        default: process.env.PNEUMATIC_TUBES_SHARED_FETCH_SECRET
+      })
+      .option('target-registry', {
+        describe: 'registry to publish to (ensure you are logged in)',
+        default: process.env.PNEUMATIC_TUBES_TARGET_REGISTRY,
+        required: true
+      })
+      .option('last-sequence', {
+        describe: 'changes feed sequence to start at',
+        default: process.env.PNEUMATIC_TUBES_LAST_SEQUENCE ? Number(process.env.PNEUMATIC_TUBES_LAST_SEQUENCE) : 0
+      })
+  })
+  .option('tmp-folder', {
+    describe: 'temporary folder to stage packages in',
+    default: '/tmp/tarballs',
+  })
+  .demandCommand(1)
+  .argv
+
+const ChangesStreamSource = require('./lib/changes-stream-source')
 
 class Tubes {
   constructor (opts) {
-    this.tmpFolder = '/tmp/tarballs'
-    mkdirp.sync('/tmp/tarballs')
+    this.opts = opts
+    this.tmpFolder = opts.tmpFolder
+    this.targetRegistry = opts.targetRegistry
+    mkdirp.sync(this.tmpFolder)
   }
-  series () {
-    const changes = new ChangesStream({
-      db: sourceCouchdb, // full database URL
-      include_docs: true, // whether or not we want to return the full document as a property,
-      since: lastSequence
-    })
-    changes.on('readable', async () => {
-      const change = changes.read()
-      console.info(`processing sequence ${change.seq}`)
-      if (change.doc && change.doc.versions) {
-        changes.pause()
-        try {
-          await this.processChange(change)
-        } catch (err) {
-          console.warn(err)
-        }
-        changes.resume()
-      }
-    })
-  }
-  async processChange (change) {
-    const versions = Object.keys(change.doc.versions)
-    for (var i = 0, version; (version = change.doc.versions[versions[i]]) !== undefined; i++) {
-      if (version.dist && version.dist.tarball) {
-        try {
-          const tarball = version.dist.tarball
-          const filename = await this.download(tarball)
-          await this.publish(filename)
-        } catch (err) {
-          console.warn(err.message)
-        }
-      }
-    }
-  }
-  download (tarball) {
-    const filename = path.resolve(this.tmpFolder, `${uuid.v4()}.tgz`)
-    return axios({
-      method: 'get',
-      url: tarball,
-      responseType: 'stream'
-    })
-      .then(function (response) {
-        return new Promise((resolve, reject) => {
-          const stream = response.data.pipe(fs.createWriteStream(filename))
-          eos(stream, err => {
-            if (err) return reject(err)
-            else return resolve()
-          })
-        })
-      })
-      .then(() => {
-        console.info(`finished writing ${filename}`)
-        return filename
-      })
+  start () {
+    new ChangesStreamSource(this, this.opts)
   }
   publish (filename) {
     return new Promise((resolve, reject) => {
-      exec(`npm --registry=${targetRegistry} publish ${filename}`, {
+      exec(`npm --registry=${this.targetRegistry} publish ${filename}`, {
         cwd: this.tmpFolder,
         env: process.env
       }, (err, stdout, stderr) => {
@@ -87,9 +59,5 @@ class Tubes {
   }
 }
 
-module.exports = function (opts) {
-  return new Tubes(opts)
-}
-
-const tubes = module.exports()
-tubes.series()
+const tubes = new Tubes(opts)
+tubes.start()

--- a/lib/changes-stream-source.js
+++ b/lib/changes-stream-source.js
@@ -1,0 +1,92 @@
+const axios = require('axios')
+const eos = require('end-of-stream')
+const fs = require('fs')
+const path = require('path')
+const uuid = require('uuid')
+
+const ChangesStream = require('changes-stream')
+
+class ChangesStreamSource {
+  constructor (tubes, opts) {
+    this.tubes = tubes
+    this.sourceCouchDb = opts.sourceCouchDb
+    this.lastSequence = opts.lastSequence
+    this.tmpFolder = opts.tmpFolder
+    this.sharedFetchSecret = opts.sharedFetchSecret
+
+    const streamOpts = {
+      db: this.sourceCouchDb, // full database URL
+      include_docs: true, // whether or not we want to return the full document as a property,
+      since: this.lastSequence
+    }
+
+    // upstream CouchDB feed might be password protected.
+    if (this.sharedFetchSecret) {
+      streamOpts.query_params = {
+        sharedFetchSecret: this.sharedFetchSecret
+      }
+    }
+
+    const changes = new ChangesStream(streamOpts)
+    changes.on('readable', async () => {
+      const change = changes.read()
+      console.info(`processing sequence ${change.seq}`)
+      if (change.doc && change.doc.versions) {
+        changes.pause()
+        try {
+          await this.processChange(change)
+        } catch (err) {
+          console.warn(err)
+        }
+        changes.resume()
+      }
+    })
+  }
+  async processChange (change) {
+    const versions = Object.keys(change.doc.versions)
+    for (var i = 0, version; (version = change.doc.versions[versions[i]]) !== undefined; i++) {
+      if (version.dist && version.dist.tarball) {
+        try {
+          const tarball = version.dist.tarball
+          const filename = await this.download(tarball)
+          if (filename) await this.tubes.publish(filename)
+        } catch (err) {
+          console.warn(err.message)
+        }
+      }
+    }
+  }
+  download (tarball) {
+    const filename = path.resolve(this.tmpFolder, `${uuid.v4()}.tgz`)
+
+    if (tarball.indexOf('@') === -1) {
+      console.warn(`${tarball} was not a scoped package`)
+      return false
+    }
+
+    console.info('downloading ', tarball)
+
+    const downloadOpts = {
+      method: 'get',
+      url: this.sharedFetchSecret ? `${tarball}?sharedFetchSecret=${this.sharedFetchSecret}` : tarball,
+      responseType: 'stream'
+    }
+
+    return axios(downloadOpts)
+      .then(function (response) {
+        return new Promise((resolve, reject) => {
+          const stream = response.data.pipe(fs.createWriteStream(filename))
+          eos(stream, err => {
+            if (err) return reject(err)
+            else return resolve()
+          })
+        })
+      })
+      .then(() => {
+        console.info(`finished writing ${filename}`)
+        return filename
+      })
+  }
+}
+
+module.exports = ChangesStreamSource

--- a/lib/changes-stream-source.js
+++ b/lib/changes-stream-source.js
@@ -13,7 +13,8 @@ class ChangesStreamSource {
     this.lastSequence = opts.lastSequence
     this.tmpFolder = opts.tmpFolder
     this.sharedFetchSecret = opts.sharedFetchSecret
-
+  }
+  async start () {
     const streamOpts = {
       db: this.sourceCouchDb, // full database URL
       include_docs: true, // whether or not we want to return the full document as a property,
@@ -27,20 +28,30 @@ class ChangesStreamSource {
       }
     }
 
-    const changes = new ChangesStream(streamOpts)
-    changes.on('readable', async () => {
-      const change = changes.read()
-      console.info(`processing sequence ${change.seq}`)
-      if (change.doc && change.doc.versions) {
-        changes.pause()
-        try {
-          await this.processChange(change)
-        } catch (err) {
-          console.warn(err)
+    try {
+      const maxSequence = await this._getMaximumSequence()
+      const changes = new ChangesStream(streamOpts)
+      changes.on('readable', async () => {
+        const change = changes.read()
+        console.info(`processing sequence ${change.seq}`)
+        if (change.doc && change.doc.versions) {
+          changes.pause()
+          try {
+            await this.processChange(change)
+          } catch (err) {
+            console.warn(err)
+          }
+          changes.resume()
         }
-        changes.resume()
-      }
-    })
+        // we've finished migrating all packages.
+        if (change.seq >= maxSequence) {
+          console.info('finished migratinng packages \\o/')
+          process.exit(0)
+        }
+      })
+    } catch (err) {
+      console.error(err.stack)
+    }
   }
   async processChange (change) {
     const versions = Object.keys(change.doc.versions)
@@ -85,6 +96,20 @@ class ChangesStreamSource {
       .then(() => {
         console.info(`finished writing ${filename}`)
         return filename
+      })
+  }
+  async _getMaximumSequence () {
+    const registryUrl = this.sourceCouchDb.replace('/_changes', '')
+
+    const downloadOpts = {
+      method: 'get',
+      url: this.sharedFetchSecret ? `${registryUrl}?sharedFetchSecret=${this.sharedFetchSecret}` : registryUrl,
+      responseType: 'json'
+    }
+
+    return axios(downloadOpts)
+      .then(response => {
+        return response.data.update_seq
       })
   }
 }

--- a/lib/changes-stream-source.js
+++ b/lib/changes-stream-source.js
@@ -33,7 +33,7 @@ class ChangesStreamSource {
       const changes = new ChangesStream(streamOpts)
       changes.on('readable', async () => {
         const change = changes.read()
-        console.info(`processing sequence ${change.seq}`)
+        console.info(`processing sequence ${change.seq}/${maxSequence}`)
         if (change.doc && change.doc.versions) {
           changes.pause()
           try {
@@ -45,7 +45,7 @@ class ChangesStreamSource {
         }
         // we've finished migrating all packages.
         if (change.seq >= maxSequence) {
-          console.info('finished migratinng packages \\o/')
+          console.info('finished migrating packages \\o/')
           process.exit(0)
         }
       })

--- a/package.json
+++ b/package.json
@@ -2,9 +2,8 @@
   "name": "pneumatic-tubes",
   "version": "1.0.1",
   "description": "migrate packages between registries (using npm publish)",
-  "main": "index.js",
+  "bin": "./index.js",
   "scripts": {
-    "import": "node index.js",
     "test": "standard"
   },
   "repository": {
@@ -27,7 +26,8 @@
     "changes-stream": "^2.2.0",
     "end-of-stream": "^1.4.1",
     "mkdirp": "^0.5.1",
-    "uuid": "^3.2.1"
+    "uuid": "^3.2.1",
+    "yargs": "^12.0.2"
   },
   "devDependencies": {
     "kappa": "^1.0.0-rc.14",


### PR DESCRIPTION
I've refactored `pneumatic-tubes` a tiny bit, adding support for migrating from our legacy npm Enterprise product.

This is in prep for adding a way to migrate from orgs.