### PR TITLE
feat: add ability to migrate orgs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 .DS_Store
 package-lock.json
 import.sh
+migrate-file.txt

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ registry.
 
 1. Visit https://www.npmjs.com.
 2. In the account drop down in the upper right corner of the page, click "Tokens".
-3. click "Create New Token", and copy this somewhere safe for later.
+3. Click "Create New Token", then copy the generated token to a local text file.
 
 ### 3. Login to your npm Enterprise instance
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ registry.
 3. Click "Create New Token", then copy the generated token to a local text file.
 
 ### 3. Login to your npm Enterprise instance
-
+As an npm Enterprise administrator, log in to your instance:
 ```
 npm config set registry https://registry.my-instance.npme.io
 npm login

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ npm config set registry https://registry.my-instance.npme.io
 npm login
 ```
 
-### 4. Create a text file containing the packages you wish to migrate
+### 4. Create a text file containing the packages in the organization you wish to migrate
 
 _Note: you can only publish scoped packages to your private registry._
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Run:
 
 You must purchase and configure an [npm Enterprise](https://www.npm-enterprise.com/) instance before you can migrate from npm Orgs to npm Enterprise.
 
-### 1. Create matching organization in npm Enterprise
+### 1. Create a matching organization in npm Enterprise
 
 You should create an organization in npm Enterprise that matches the name of
 the organization that you wish to migrate from in npm Orgs.

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ the organization that you wish to migrate from in the public registry.
 As an example, if you want to migrate from your organization `@babel` on the
 public registry, create an organization named `babel` in npm Enterprise.
 
-### 2. Create an authorization token
+### 2. Create an authorization token on the npm public registry
 
 To migrate from npm Orgs, you need an authorization token from the public
 registry.

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ registry.
 2. in the account drop down in the upper right, choose the option "Tokens".
 3. click "Create New Token", and copy this somewhere safe for later.
 
-### 3. Login to your npm Enterprise Instance
+### 3. Login to your npm Enterprise instance
 
 ```
 npm config set registry https://registry.my-instance.npme.io

--- a/README.md
+++ b/README.md
@@ -31,6 +31,10 @@ Run:
 
 ## Importing From npm Orgs
 
+### Prerequisites
+
+You must purchase and configure an [npm Enterprise](https://www.npm-enterprise.com/) instance before you can migrate from npm Orgs to npm Enterprise.
+
 ### 1. Create matching organization in npm Enterprise
 
 You should create an organization in npm Enterprise that matches the name of

--- a/README.md
+++ b/README.md
@@ -29,6 +29,55 @@ Run:
 ./index.js couch-import --source-couch-db=[couch-db-url]/_changes --target-registry=[target-registry-url] --shared-fetch-secret=[password-from-console]
 ```
 
+## Importing From npm Orgs
+
+### 1. Create matching organization in npm Enterprise
+
+You should create an organization in npm Enterprise that matches the name of
+the organization that you wish to migrate from in npm Orgs.
+
+As an example, if you want to migrate from your organization `@babel` on the
+public registry, create an organization named `babel` in npm Enterprise.
+
+### 2. Create an authorization token
+
+To migrate from npm Orgs, you need an authorization token from the public
+registry.
+
+1. visit `https://www.npmjs.com`.
+2. in the account drop down in the upper right, choose the option "Tokens".
+3. click "Create New Token", and copy this somewhere safe for later.
+
+### 3. Login to your npm Enterprise Instance
+
+```
+npm config set registry https://registry.my-instance.npme.io
+npm login
+```
+
+### 4. Create a text file containing the packages you wish to migrate
+
+_Note: you can only publish scoped modules to your private registry._
+
+The text file should look something like this:
+
+```
+@babel/runtime
+@babel/core
+@babel/template
+```
+
+### 5. Run the migration tool
+
+It's now time to run the migration tool, using the token and text file that
+you generated.
+
+_Note: this will migrate all versions of your module._
+
+```
+./index.js orgs-import --source-token=[redacted] --target-registry=https://registry.my-instance.npme.io --migrate-file=migrate-file.txt
+```
+
 ## Development
 
 If you are making changes to `pneumatic-tubes`, you can test using a local kappa.

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ public registry, create an organization named `babel` in npm Enterprise.
 To migrate from npm Orgs, you need an authorization token from the public
 registry.
 
-1. visit `https://www.npmjs.com`.
+1. Visit https://www.npmjs.com.
 2. in the account drop down in the upper right, choose the option "Tokens".
 3. click "Create New Token", and copy this somewhere safe for later.
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ npm login
 
 ### 4. Create a text file containing the packages you wish to migrate
 
-_Note: you can only publish scoped modules to your private registry._
+_Note: you can only publish scoped packages to your private registry._
 
 The text file should look something like this:
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ You must purchase and configure an [npm Enterprise](https://www.npm-enterprise.c
 ### 1. Create a matching organization in npm Enterprise
 
 You should create an organization in npm Enterprise that matches the name of
-the organization that you wish to migrate from in npm Orgs.
+the organization that you wish to migrate from in the public registry.
 
 As an example, if you want to migrate from your organization `@babel` on the
 public registry, create an organization named `babel` in npm Enterprise.

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ The text file should look something like this:
 It's now time to run the migration tool, using the token and text file that
 you generated.
 
-_Note: this will migrate all versions of your module._
+_Note: this will migrate all versions of each package listed in the text file._
 
 ```
 ./index.js orgs-import --source-token=[redacted] --target-registry=https://registry.my-instance.npme.io --migrate-file=migrate-file.txt

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ To migrate from npm Orgs, you need an authorization token from the public
 registry.
 
 1. Visit https://www.npmjs.com.
-2. in the account drop down in the upper right, choose the option "Tokens".
+2. In the account drop down in the upper right corner of the page, click "Tokens".
 3. click "Create New Token", and copy this somewhere safe for later.
 
 ### 3. Login to your npm Enterprise instance

--- a/README.md
+++ b/README.md
@@ -31,37 +31,18 @@ Run:
 
 ## Importing From npm Orgs
 
-### Prerequisites
-
-You must purchase and configure an [npm Enterprise](https://www.npm-enterprise.com/) instance before you can migrate from npm Orgs to npm Enterprise.
-
-### 1. Create a matching organization in npm Enterprise
-
-You should create an organization in npm Enterprise that matches the name of
-the organization that you wish to migrate from in the public registry.
-
-As an example, if you want to migrate from your organization `@babel` on the
-public registry, create an organization named `babel` in npm Enterprise.
-
-### 2. Create an authorization token on the npm public registry
+### 1. Create an authorization token
 
 To migrate from npm Orgs, you need an authorization token from the public
 registry.
 
-1. Visit https://www.npmjs.com.
-2. In the account drop down in the upper right corner of the page, click "Tokens".
-3. Click "Create New Token", then copy the generated token to a local text file.
+1. visit `https://www.npmjs.com`.
+2. in the account drop down in the upper right, choose the option "Tokens".
+3. click "Create New Token", and copy this somewhere safe for later.
 
-### 3. Login to your npm Enterprise instance
-As an npm Enterprise administrator, log in to your instance:
-```
-npm config set registry https://registry.my-instance.npme.io
-npm login
-```
+### 2. Create a text file containing the packages you wish to migrate
 
-### 4. Create a text file containing the packages in the organization you wish to migrate
-
-_Note: you can only publish scoped packages to your private registry._
+_Note: you can only publish scoped modules to your private registry._
 
 The text file should look something like this:
 
@@ -71,15 +52,30 @@ The text file should look something like this:
 @babel/template
 ```
 
+### 3. Login to your npm Enterprise Instance
+
+```
+npm config set registry https://registry.my-instance.npme.io
+npm login
+```
+
+### 4. Create matching organization in npm Enterprise
+
+You should create an organization in npm Enterprise that matches the name of
+the organization that you wish to migrate from in npm Orgs.
+
+As an example, if you want to migrate from your organization `@babel` on the
+public registry, create an organization named `babel` in npm Enterprise.
+
 ### 5. Run the migration tool
 
 It's now time to run the migration tool, using the token and text file that
 you generated.
 
-_Note: this will migrate all versions of each package listed in the text file._
+_Note: this will migrate all versions of your module._
 
 ```
-./index.js orgs-import --source-token=[redacted] --target-registry=https://registry.my-instance.npme.io --migrate-file=migrate-file.txt
+./index.js orgs-import --source-token=[redacted] --target-registry=https://registry..npme.io --migrate-file=migrate-file.txt
 ```
 
 ## Development

--- a/lib/orgs-source.js
+++ b/lib/orgs-source.js
@@ -1,0 +1,90 @@
+const axios = require('axios')
+const eos = require('end-of-stream')
+const fs = require('fs')
+const path = require('path')
+const uuid = require('uuid')
+
+class OrgsSource {
+  constructor (tubes, opts) {
+    this.tubes = tubes
+    this.tmpFolder = opts.tmpFolder
+    this.sourceRegistry = opts.sourceRegistry
+    this.sourceToken = opts.sourceToken
+    this.migrateFile = opts.migrateFile
+  }
+  async start () {
+    try {
+      const packages = fs.readFileSync(this.migrateFile, 'utf8').trim().split(/\r?\n/)
+      for (let i = 0, pkg; (pkg = packages[i]) !== undefined; i++) {
+        const json = await this.getJson(pkg)
+        await this.processJson(json)
+      }
+    } catch (err) {
+      console.warn(err.stack)
+    }
+  }
+  async getJson (pkgName) {
+    const getOpts = {
+      method: 'get',
+      headers: {
+        authorization: `bearer ${this.sourceToken}`
+      },
+      url: `${this.sourceRegistry}/${pkgName.replace('/', '%2F')}`
+    }
+
+    return axios(getOpts)
+      .then(function (response) {
+        return response.data
+      })
+  }
+  async processJson (json) {
+    const versions = Object.keys(json.versions)
+    for (var i = 0, version; (version = json.versions[versions[i]]) !== undefined; i++) {
+      if (version.dist && version.dist.tarball) {
+        try {
+          const tarball = version.dist.tarball
+          const filename = await this.download(tarball)
+          if (filename) await this.tubes.publish(filename)
+        } catch (err) {
+          console.warn(err.message)
+        }
+      }
+    }
+  }
+  download (tarball) {
+    const filename = path.resolve(this.tmpFolder, `${uuid.v4()}.tgz`)
+
+    if (tarball.indexOf('@') === -1) {
+      console.warn(`${tarball} was not a scoped package`)
+      return false
+    }
+
+    console.info('downloading ', tarball)
+
+    const downloadOpts = {
+      method: 'get',
+      url: tarball,
+      responseType: 'stream',
+      headers: {
+        authorization: `bearer ${this.sourceToken}`
+      }
+    }
+
+    return axios(downloadOpts)
+      .then(function (response) {
+        return new Promise((resolve, reject) => {
+          const stream = response.data.pipe(fs.createWriteStream(filename))
+          eos(stream, err => {
+            if (err) return reject(err)
+            else return resolve()
+          })
+        })
+      })
+      .then(() => {
+        console.info(`finished writing ${filename}`)
+        return filename
+      })
+  }
+}
+
+module.exports = OrgsSource


### PR DESCRIPTION
adds the ability to migrate npm Orgs to npm Enterprise SaaS (using a list of packages the user provides, no magic yet).