### PR TITLE
chore: allow skipping some (or all) versions of specific packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,17 @@ Run:
 pneumatic-tubes couch-import --source-couch-db=[couch-db-url]/_changes --target-registry=[target-registry-url] --shared-fetch-secret=[password-from-console]
 ```
 
+You may pass a `--scopes=@example` parameter to limit the import to one (or more, if specified multiple times) scopes.
+
+You may also skip specific semver ranges of specific packages by creating a text file and passing its path with `--exceptions=exceptions.txt`. Each line in this file must be the name of a package, followed by a space, followed by a semver range. For example:
+
+```
+@myorg/mypackage < 1.0.0
+@myorg/packageidontwant *
+```
+
+Would cause pneumatic-tubes to skip any version of `@myorg/mypackage` before version `1.0.0` and _all_ versions of `@myorg/packageidontwant`.
+
 ## Importing From npm Orgs
 
 ### 1. Create an authorization token

--- a/index.js
+++ b/index.js
@@ -98,6 +98,10 @@ const opts = require('yargs')
       return verified
     }
   })
+  .option('exceptions', {
+    desc: 'a newline delimited file containing package name and semver ranges to exclude from synchronization',
+    required: false
+  })
   .option('trace-log', {
     type: 'boolean',
     desc: 'turn on extra detailed logging for tracking down issues with tarball transformations',

--- a/lib/changes-stream-source.js
+++ b/lib/changes-stream-source.js
@@ -3,6 +3,7 @@ const eos = require('end-of-stream')
 const fs = require('fs')
 const path = require('path')
 const removeFile = require('./remove-file')
+const semver = require('semver')
 const transformTarball = require('./transform-tarball')
 const uuid = require('uuid/v4')
 
@@ -20,6 +21,25 @@ class ChangesStreamSource {
     this.tmpFolder = opts.tmpFolder
     this.traceLog = opts.traceLog
     this.tubes = tubes
+    this.exceptions = {}
+    if (opts.exceptions) {
+      const rawExceptions = fs.readFileSync(path.resolve(process.cwd(), opts.exceptions), { encoding: 'utf8' })
+      for (let line of rawExceptions.split(/\n/)) {
+        line = line.trim()
+        if (!line) {
+          continue
+        }
+
+        const space = line.indexOf(' ')
+        if (space === -1) {
+          this.exceptions[line] = '*'
+        } else {
+          const name = line.slice(0, space)
+          const range = line.slice(space + 1)
+          this.exceptions[name] = range
+        }
+      }
+    }
   }
 
   async start () {
@@ -42,7 +62,10 @@ class ChangesStreamSource {
       changes.on('error', err => console.warn(err))
       changes.on('readable', async () => {
         const change = changes.read()
-        console.info(`processing sequence ${change.seq}/${maxSequence}`)
+        if (this.traceLog) {
+          console.info(`processing sequence ${change.seq}/${maxSequence}`)
+        }
+
         if (change.doc && change.doc.versions) {
           changes.pause()
           try {
@@ -64,8 +87,32 @@ class ChangesStreamSource {
   }
 
   async processChange (change) {
+    if (!change.doc._id.startsWith('@')) {
+      if (this.traceLog) {
+        console.info(`Skipping ${change.doc._id} (not scoped)`)
+      }
+      return
+    }
+
+    const scope = change.doc._id.slice(0, change.doc._id.indexOf('/'))
+    if (this.scopes) {
+      if (!this.scopes.includes(scope)) {
+        if (this.traceLog) {
+          console.info(`Skipping tarball ${tarball} (not in the scopes list)`)
+        }
+        return
+      }
+    }
+
     const versions = Object.keys(change.doc.versions)
     for (var i = 0, version; (version = change.doc.versions[versions[i]]) !== undefined; i++) {
+      if (this.exceptions.hasOwnProperty(version.name) && semver.satisfies(version.version, this.exceptions[version.name])) {
+        if (this.traceLog) {
+          console.info(`Skipping ${version.name}@${version.version} (matches exception range '${this.exceptions[version.name]}')`)
+        }
+        continue
+      }
+
       if (version.dist && version.dist.tarball) {
         try {
           const tarball = version.dist.tarball
@@ -86,23 +133,6 @@ class ChangesStreamSource {
 
   download (tarball) {
     const filename = path.resolve(this.tmpFolder, `${uuid()}.tgz`)
-
-    const [, scope] = tarball.match(/[/](@[^/]+)[/]/) || []
-
-    if (!scope) {
-      console.warn(`${tarball} was not a scoped package`)
-      return false
-    }
-
-    if (this.scopes) {
-      if (!scope || !this.scopes.includes(scope)) {
-        if (this.traceLog) {
-          console.info(`Skipping tarball ${tarball} (not in the scopes list)`)
-        }
-        return false
-      }
-    }
-
     console.info('downloading ', tarball)
 
     const downloadOpts = {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "end-of-stream": "^1.4.1",
     "gunzip-maybe": "^1.4.1",
     "mkdirp": "^0.5.1",
+    "semver": "^7.1.3",
     "standard-version": "^7.0.0",
     "stream-buffers": "^3.0.2",
     "tar-stream": "^2.1.0",


### PR DESCRIPTION
# What / Why
<!-- Describe the request in detail -->
> This allows the couch-import command to exclude specific versions (or indeed all versions) of specific packages based on a given semver range

## References
<!-- Examples
  * Related to #0
  * Depends on #0
  * Blocked by #0
  * Closes #0
-->
* n/a
