### PR TITLE
Fix tarball package.json registry update.

### DIFF
--- a/lib/transform-tarball.js
+++ b/lib/transform-tarball.js
@@ -77,8 +77,7 @@ async function transformTarball (tarball, {
               outBuffer.put(JSON.stringify(pkg, null, 2) + '\n', 'utf8')
             }
             outBuffer.stop()
-            header.size = outBuffer.size()
-            outBuffer.pipe(pack.entry(header, callback))
+            outBuffer.pipe(pack.entry({...header, size: outBuffer.size()}, callback))
           })
       } else {
         // Forward the entry into the new tarball unmodified.


### PR DESCRIPTION
# What / Why
Currently when you try to update the `publishConfig.registry` value it throws an error that the tar headers are corrupted.

What I believe is happening is the `header` object is a reference to a slice of a buffer, so when the `size` value is updated it updates the buffer in the stream. Then when `extract` attempts to read the next header slice it grabs an invalid chunk of data and the header is corrupted.

This fixes it by creating a copy of the header before updating the size and passing it on to the `pack.entry` method.,

## References
  * Fixes #9  
